### PR TITLE
Update gems to latest heroku-18 supports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
+
 # It's easy to add more libraries or choose different versions. Any libraries
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
 
-ruby "3.2.2"
+ruby "3.2.2" # ruby 3.2.3 does NOT run on heroku-18!
 
 gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
-gem "mechanize", "~> 2.8.5"
-gem "nokogiri", "~> 1.15.0"
-gem "sqlite3", "~> 1.6.3"
-
+gem "mechanize", "~> 2.14"
+gem "nokogiri", "~> 1.17.2" # nokogiri 1.18 does NOT run on heroku-18!
+gem "sqlite3", "~> 2.2.0" # sqlite3 2.3.0 does NOT run on heroku-18!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,23 +10,25 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
-    connection_pool (2.5.4)
+    connection_pool (3.0.2)
     domain_name (0.6.20240107)
-    http-cookie (1.1.0)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
     logger (1.7.0)
-    mechanize (2.8.5)
+    mechanize (2.14.0)
       addressable (~> 2.8)
+      base64
       domain_name (~> 0.5, >= 0.5.20190701)
       http-cookie (~> 1.0, >= 1.0.3)
-      mime-types (~> 3.0)
+      mime-types (~> 3.3)
       net-http-digest_auth (~> 1.4, >= 1.4.1)
       net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
       nokogiri (~> 1.11, >= 1.11.2)
       rubyntlm (~> 0.6, >= 0.6.3)
       webrick (~> 1.7)
@@ -34,34 +36,43 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0924)
+    mime-types-data (3.2026.0701)
     mini_portile2 (2.8.9)
     mutex_m (0.3.0)
     net-http-digest_auth (1.4.1)
-    net-http-persistent (4.0.6)
-      connection_pool (~> 2.2, >= 2.2.4)
-    nokogiri (1.15.7)
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
+    nkf (0.3.0)
+    nokogiri (1.17.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    public_suffix (6.0.2)
+    nokogiri (1.17.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.17.2-x86_64-linux)
+      racc (~> 1.4)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rubyntlm (0.6.5)
       base64
-    sqlite3 (1.6.9)
+    sqlite3 (2.2.0)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (2.2.0-arm64-darwin)
+    sqlite3 (2.2.0-x86_64-linux-gnu)
     sqlite_magic (0.0.6)
       sqlite3
-    webrick (1.9.1)
+    webrick (1.9.2)
     webrobots (0.1.2)
 
 PLATFORMS
+  arm64-darwin
   ruby
+  x86_64-linux
 
 DEPENDENCIES
-  mechanize (~> 2.8.5)
-  nokogiri (~> 1.15.0)
+  mechanize (~> 2.14)
+  nokogiri (~> 1.17.2)
   scraperwiki!
-  sqlite3 (~> 1.6.3)
+  sqlite3 (~> 2.2.0)
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,3 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+Bundler.require
+
 require "mechanize"
 require "json"
 require "scraperwiki"


### PR DESCRIPTION
## Description

Update gems to the latest versions supported by heroku-18 (morph.io's platform): mechanize ~> 2.14, nokogiri ~> 1.17.2, sqlite3 ~> 2.2.0. Add standalone header to scraper.rb (`bundler/setup` + `Bundler.require`) so it runs directly, and make it executable. Add `# frozen_string_literal: true` to the Gemfile. Regenerate Gemfile.lock for ruby 3.2.2 with the x86_64-linux platform. (This repo has no dev/test gems, so no `group :development` was needed.)

## Motivation and Context

heroku-18 caps the gem versions morph.io can run (ruby 3.2.3, nokogiri 1.18 and sqlite3 2.3.0 all fail there). This applies the same pattern as the merged PRs planningalerts-scrapers/bawbaw#6, planningalerts-scrapers/banyule#10 and planningalerts-scrapers/multiple_technology_one#35, and replaces pending dependabot PRs.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

bundle install under ruby 3.2.2 via mise; `bundle lock --add-platform x86_64-linux` (arm64-darwin also added for local dev); local smoke run fetched and saved records successfully (7 records in ~3 minutes — this scraper deliberately throttles to one request every 15–25 s).

- [ ] Ran automated tests on my own system (no specs in this repo)
- [ ] Confirmed it passed the GitHub actions tests (no workflows in this repo)

## Screenshots (if appropriate):

N/A

## Types of Changes

Dependency update — no functional change to scraping behaviour.
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
Note: a verification run on morph.io under a fork is advisable before merging.

Assisted-by: OpenCode/anthropic.claude-fable-5

